### PR TITLE
fix: 가나다순 정렬 및 이력서 필수로 수정

### DIFF
--- a/src/modules/blogs/repository/blog.repository.ts
+++ b/src/modules/blogs/repository/blog.repository.ts
@@ -113,7 +113,7 @@ export class BlogRepository {
             skip: offset,
             take: limit,
             orderBy: {
-                createdAt: Prisma.SortOrder.desc,
+                title: 'asc',
             },
         });
         this.logger.debug(

--- a/src/modules/blogs/test/blog.repository.spec.ts
+++ b/src/modules/blogs/test/blog.repository.spec.ts
@@ -98,7 +98,7 @@ describe('BlogRepository', (): void => {
                 skip: getBlogsQueryRequest.offset,
                 take: getBlogsQueryRequest.limit,
                 orderBy: {
-                    createdAt: Prisma.SortOrder.desc,
+                    title: 'asc',
                 },
             });
             expect(prismaService.blog.findMany).toHaveBeenCalledTimes(1);

--- a/src/modules/projectTeams/projectTeam.service.ts
+++ b/src/modules/projectTeams/projectTeam.service.ts
@@ -1421,12 +1421,10 @@ export class ProjectTeamService {
                         : team.isFinished === isFinished),
             );
 
-            // teamTypes가 주어지지 않으면 filteredProjects와 filteredStudies를 합쳐서 반환
+            // teamTypes가 주어지지 않으면 filteredProjects와 filteredStudies를 합쳐서 반환(가나다 순)
             const allTeams = !teamTypes
-                ? [...filteredProjects, ...filteredStudies].sort(
-                      (a, b) =>
-                          new Date(b.createdAt).getTime() -
-                          new Date(a.createdAt).getTime(), // 날짜 순으로 정렬
+                ? [...filteredProjects, ...filteredStudies].sort((a, b) =>
+                      a.name.localeCompare(b.name),
                   )
                 : [];
 

--- a/src/modules/resumes/repository/resume.repository.ts
+++ b/src/modules/resumes/repository/resume.repository.ts
@@ -158,7 +158,7 @@ export class ResumeRepository {
             skip: offset,
             take: limit,
             orderBy: {
-                createdAt: Prisma.SortOrder.desc,
+                title: 'asc',
             },
         });
         this.logger.debug(
@@ -188,7 +188,7 @@ export class ResumeRepository {
             skip: offset,
             take: limit,
             orderBy: {
-                createdAt: Prisma.SortOrder.desc,
+                title: 'asc',
             },
         });
         this.logger.debug(

--- a/src/modules/resumes/test/resume.repository.spec.ts
+++ b/src/modules/resumes/test/resume.repository.spec.ts
@@ -11,7 +11,6 @@ import {
     user,
 } from './mock-data';
 import { ResumeEntity } from '../entities/resume.entity';
-import { Prisma } from '@prisma/client';
 import { NotFoundResumeException } from '../../../global/exception/custom.exception';
 import { CustomWinstonLogger } from '../../../global/logger/winston.logger';
 import { IndexService } from '../../../global/index/index.service';
@@ -154,7 +153,7 @@ describe('ResumeRepository', (): void => {
                 skip: getResumesQueryRequest.offset,
                 take: getResumesQueryRequest.limit,
                 orderBy: {
-                    createdAt: Prisma.SortOrder.desc,
+                    title: 'asc',
                 },
             });
             expect(prismaService.resume.findMany).toHaveBeenCalledTimes(1);
@@ -184,7 +183,7 @@ describe('ResumeRepository', (): void => {
                 skip: paginationQueryDto.offset,
                 take: paginationQueryDto.limit,
                 orderBy: {
-                    createdAt: Prisma.SortOrder.desc,
+                    title: 'asc',
                 },
             });
             expect(prismaService.resume.findMany).toHaveBeenCalledTimes(1);

--- a/src/modules/sessions/repository/session.repository.ts
+++ b/src/modules/sessions/repository/session.repository.ts
@@ -135,6 +135,9 @@ export class SessionRepository {
             },
             skip: offset,
             take: limit,
+            orderBy: {
+                title: 'asc',
+            },
         });
     }
 

--- a/src/modules/sessions/test/session.repository.spec.ts
+++ b/src/modules/sessions/test/session.repository.spec.ts
@@ -200,6 +200,9 @@ describe('SessionRepository', (): void => {
                 include: { user: true },
                 skip: getSessionsQueryRequest.offset,
                 take: getSessionsQueryRequest.limit,
+                orderBy: {
+                    title: 'asc',
+                },
             });
             expect(prismaService.session.findMany).toHaveBeenCalledTimes(1);
         });

--- a/src/modules/users/repository/user.repository.ts
+++ b/src/modules/users/repository/user.repository.ts
@@ -427,6 +427,7 @@ export class UserRepository {
                     },
                     skip: offset || 0,
                     take: limit || 10,
+                    orderBy: { name: 'asc' },
                     include: {
                         projectMembers: {
                             where: {

--- a/src/modules/users/user.service.ts
+++ b/src/modules/users/user.service.ts
@@ -16,6 +16,7 @@ import {
     UnauthorizedAdminException,
     NotFoundTecheerException,
     NotFoundUserException,
+    NotFoundResumeException,
 } from '../../global/exception/custom.exception';
 import { TaskService } from '../../global/task/task.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -119,6 +120,14 @@ export class UserService {
                 '경력 생성 완료',
                 JSON.stringify({ context: UserService.name }),
             );
+
+            // 파일 검증: 파일이 없으면 예외 처리
+            if (!file) {
+                this.logger.error('이력서 파일이 없습니다.', {
+                    context: UserService.name,
+                });
+                throw new NotFoundResumeException(); // 혹은 BadRequestException으로 변경 가능
+            }
 
             // 이력서 저장
             if (file && resumeData) {


### PR DESCRIPTION
## 요약

- 프로젝트 & 스터디, 프로필, 이력서, 블로그, 세션 가나다순 정렬
- 이력서 필수로 업로드 하도록 수정

<br><br>

## 작업 내용

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

SCRUM-264

<br><br>
