### PR TITLE
fix: 프로젝트, 스터디 멤버 삭제 추가 로직 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
         "@types/node": "^20.17.10",
         "@types/qs": "^6.9.15",
         "@types/supertest": "^6.0.0",
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^7.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.25.0",
+        "@typescript-eslint/parser": "^8.25.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -91,7 +91,7 @@
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.5.4",
-        "typescript-eslint": "^8.2.0"
+        "typescript-eslint": "8.2.0"
     },
     "jest": {
         "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
         "ts-loader": "^9.4.3",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "5.5.4",
-        "typescript-eslint": "8.2.0"
+        "typescript": "5.5.4"
     },
     "jest": {
         "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "ts-loader": "^9.4.3",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.5.4",
+        "typescript": "5.5.4",
         "typescript-eslint": "8.2.0"
     },
     "jest": {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -136,7 +136,7 @@ async function main(): Promise<void> {
         },
         {
             name: 'Redis',
-            category: 'BACKEND',
+            category: 'DATABASE',
         },
         {
             name: 'MSA',

--- a/src/global/exception/custom.exception.ts
+++ b/src/global/exception/custom.exception.ts
@@ -272,3 +272,27 @@ export class NoLeaderException extends HttpException {
         super('최소 한 명의 리더가 있어야 합니다.', HttpStatus.BAD_REQUEST);
     }
 }
+
+export class NoPositionException extends HttpException {
+    constructor() {
+        super('모든 팀원은 포지션을 선택해야 합니다.', HttpStatus.BAD_REQUEST);
+    }
+}
+
+export class NoRecruitmentSpaceException extends HttpException {
+    constructor() {
+        super(
+            '모집 가능한 인원이 0명으로 더 이상 모집할 수 없습니다.',
+            HttpStatus.BAD_REQUEST,
+        );
+    }
+}
+
+export class NotFoundApplicantException extends HttpException {
+    constructor() {
+        super(
+            '모집 가능한 인원이 0명으로 더 이상 모집할 수 없습니다.',
+            HttpStatus.BAD_REQUEST,
+        );
+    }
+}

--- a/src/modules/studyTeams/repository/studyTeam.repository.ts
+++ b/src/modules/studyTeams/repository/studyTeam.repository.ts
@@ -176,11 +176,27 @@ export class StudyTeamRepository {
         this.logger.debug(
             `🗑️ [START] deleteMembers - 삭제할 멤버 ID: ${memberIds}`,
         );
-        await this.prisma.studyMember.updateMany({
-            where: { id: { in: memberIds } },
-            data: { isDeleted: true },
-        });
-        this.logger.debug('✅ [SUCCESS] 멤버 삭제 완료');
+
+        try {
+            await this.prisma.studyMember.updateMany({
+                where: {
+                    userId: { in: memberIds },
+                },
+                data: {
+                    isDeleted: true,
+                },
+            });
+
+            this.logger.debug(
+                `✅ [SUCCESS] 스터디 멤버 삭제 처리 완료: ${memberIds.join(', ')}`,
+            );
+        } catch (error) {
+            this.logger.error(
+                '❌ [ERROR] deleteMembers 에서 예외 발생: ',
+                error,
+            );
+            throw new Error('스터디 멤버 삭제 중 오류가 발생했습니다.');
+        }
     }
 
     async updateStudyTeam(
@@ -190,12 +206,30 @@ export class StudyTeamRepository {
         studyMembers: { userId: number; isLeader: boolean }[] = [], // 기본값 추가
     ): Promise<GetStudyTeamResponse> {
         try {
-            // ✅ studyMembers가 존재할 때만 map()을 실행
+            // 이름 중복 검사 - 수정하려는 스터디 제외하고 동일 이름 존재 여부 확인
+            if (updateData.name) {
+                const existingStudyWithSameName =
+                    await this.prisma.studyTeam.findFirst({
+                        where: {
+                            name: updateData.name,
+                            id: { not: id }, // 현재 수정 중인 스터디는 제외
+                            isDeleted: false, // 삭제되지 않은 스터디만 검사
+                        },
+                    });
+
+                if (existingStudyWithSameName) {
+                    this.logger.error(
+                        '이미 동일한 이름의 스터디가 존재합니다.',
+                    );
+                }
+            }
+
             const userIds =
                 Array.isArray(studyMembers) && studyMembers.length > 0
                     ? studyMembers.map((member) => member.userId)
                     : [];
 
+            // 삭제된 멤버도 포함하여 조회하도록 수정
             const existingStudyMembers =
                 (await this.prisma.studyMember.findMany({
                     where: {
@@ -205,8 +239,30 @@ export class StudyTeamRepository {
                     select: {
                         id: true,
                         userId: true,
+                        isDeleted: true,
                     },
                 })) || [];
+
+            // 삭제된 멤버 중 다시 추가되는 멤버들 찾기
+            const deletedMembersToReactivate = existingStudyMembers.filter(
+                (member) => member.isDeleted === true,
+            );
+
+            // 삭제된 멤버를 다시 활성화
+            if (deletedMembersToReactivate.length > 0) {
+                await this.prisma.studyMember.updateMany({
+                    where: {
+                        id: {
+                            in: deletedMembersToReactivate.map(
+                                (member) => member.id,
+                            ),
+                        },
+                    },
+                    data: {
+                        isDeleted: false,
+                    },
+                });
+            }
 
             const studyMemberIdMap = Array.isArray(existingStudyMembers)
                 ? existingStudyMembers.reduce((acc, member) => {
@@ -229,6 +285,7 @@ export class StudyTeamRepository {
                               },
                               update: {
                                   isLeader: member.isLeader,
+                                  isDeleted: false,
                               },
                           };
                       })
@@ -254,6 +311,7 @@ export class StudyTeamRepository {
                 include: {
                     resultImages: true,
                     studyMember: {
+                        where: { isDeleted: false }, // 활성 멤버만 포함하도록
                         include: {
                             user: {
                                 select: {


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용
- 프로젝트, 스터디 멤버 삭제 추가 로직 수정 완료 (삭제 하고 다시 추가 안 됐던 부분)
- 프로젝트를 생성, 수정할 때 포지션을 선택 안 하면 애초에 공고 생성 자체가 안 되도록 수정 완료
- 모집인원이 0명이면 애초에 isRecruited 가 무조건 false가 되도록 수정 완료 
- 한명씩 뽑을 수록 -1씩 줄어드는데 0이 됐으면 더이상 -1이 안 되도록 예외 추가 완료
- 모집 인원이 0명이더라도 이미 지원한 사람에 대해서는 승인이 가능하게 하고 isRecruited를 false로 설정하여 추가 지원은 받지 않도록 수정 완료
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

SCRUM-262

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 프로젝트 및 스터디 팀 관리 기능을 강화하여, 팀원 포지션 검증과 채용 상태 업데이트가 보다 명확하게 반영됩니다.
	- 중복 팀 이름 확인 및 삭제된 팀원 재활성화 기능이 추가되어 사용자 경험이 향상되었습니다.
- **Bug Fixes**
	- 채용 인원 수가 0 이하일 때 발생할 수 있는 이상 동작을 개선하여, 채용 상태 업데이트 문제를 해결했습니다.
- **Chores**
	- 내부 오류 로깅 및 기술 스택 분류 개선 작업이 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->