### PR TITLE
fix: 리더 여러명인 경우 슬랙 알림 로직 수정 및 이미지 확장자 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "ts-loader": "^9.4.3",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.5.4"
+        "typescript": "5.5.4"
     },
     "jest": {
         "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
         "@types/node": "^20.17.10",
         "@types/qs": "^6.9.15",
         "@types/supertest": "^6.0.0",
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^7.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.25.0",
+        "@typescript-eslint/parser": "^8.25.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -90,8 +90,7 @@
         "ts-loader": "^9.4.3",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.5.4",
-        "typescript-eslint": "^8.2.0"
+        "typescript": "^5.5.4"
     },
     "jest": {
         "moduleFileExtensions": [

--- a/src/modules/alert/alert.service.ts
+++ b/src/modules/alert/alert.service.ts
@@ -29,7 +29,9 @@ export class AlertServcie {
     /**
      * 공고에 지원/승인/거절 등 사용자에게 전달(슬랙 개인 디엠)할 알림을 전송합니다.
      */
-    async sendUserAlert(payload: CreatePersonalAlertRequest): Promise<void> {
+    async sendUserAlert(
+        payload: CreatePersonalAlertRequest | CreatePersonalAlertRequest[],
+    ): Promise<void> {
         try {
             await axios.post(SLACKBOT_PERSONAL_URL, payload);
             this.logger.debug('User alert sent successfully!');

--- a/src/modules/alert/dto/request/create.project.alert.request.ts
+++ b/src/modules/alert/dto/request/create.project.alert.request.ts
@@ -8,8 +8,8 @@ export class CreateProjectAlertRequest {
     dataEngNum: number;
     devOpsNum: number;
     fullStackNum: number;
-    leader: string;
-    email: string;
+    leader: string[];
+    email: string[];
     recruitExplain: string;
     notionLink: string;
     stack: string[];

--- a/src/modules/alert/dto/request/create.study.alert.request.ts
+++ b/src/modules/alert/dto/request/create.study.alert.request.ts
@@ -4,8 +4,8 @@ export class CreateStudyAlertRequest {
     name: string;
     studyExplain: string;
     recruitNum: number;
-    leader: string;
-    email: string;
+    leader: string[];
+    email: string[];
     recruitExplain: string;
     notionLink: string;
     goal: string;

--- a/src/modules/stacks/dto/request/post.stack.request.ts
+++ b/src/modules/stacks/dto/request/post.stack.request.ts
@@ -1,4 +1,4 @@
-import { StackCategory } from '../../../../global/category/stack.category';
+import { StackCategory } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsString } from 'class-validator';
 

--- a/src/modules/studyTeams/studyTeam.service.ts
+++ b/src/modules/studyTeams/studyTeam.service.ts
@@ -70,7 +70,21 @@ export class StudyTeamService {
         files: Express.Multer.File[],
         folder: string,
     ): Promise<string[]> {
-        const allowedExtensions = ['jpg', 'jpeg', 'png', 'gif'];
+        const allowedExtensions = [
+            'jpg',
+            'jpeg',
+            'png',
+            'gif',
+            'svg',
+            'webp',
+            'bmp',
+            'tiff',
+            'ico',
+            'heic',
+            'heif',
+            'raw',
+            'psd',
+        ];
 
         try {
             const imageUrls = await Promise.all(
@@ -189,13 +203,18 @@ export class StudyTeamService {
             );
 
             // Slack 알림에 사용할 DTO 매핑
-            const leaderMember = studyData.studyMember.find(
+            const leaderMembers = studyData.studyMember.filter(
                 (member) => member.isLeader,
             );
-            const leaderName = leaderMember
-                ? leaderMember.name
-                : 'Unknown Leader';
-            const leaderEmail = leaderMember ? leaderMember.email : 'No Email';
+
+            // 리더 이름과 이메일을 배열로 저장
+            const leaderNames = leaderMembers.length
+                ? leaderMembers.map((leader) => leader.name) // 🔹 배열 유지
+                : ['Unknown Leader'];
+
+            const leaderEmails = leaderMembers.length
+                ? leaderMembers.map((leader) => leader.email) // 🔹 배열 유지
+                : ['No Email'];
 
             const slackPayload: CreateStudyAlertRequest = {
                 id: studyData.id,
@@ -203,8 +222,8 @@ export class StudyTeamService {
                 name: studyData.name,
                 studyExplain: studyData.studyExplain,
                 recruitNum: studyData.recruitNum,
-                leader: leaderName,
-                email: leaderEmail,
+                leader: leaderNames, // 여러 명일 경우 ,로 구분
+                email: leaderEmails, // 여러 명일 경우 ,로 구분
                 recruitExplain: studyData.recruitExplain,
                 notionLink: studyData.notionLink,
                 goal: studyData.goal,
@@ -272,6 +291,10 @@ export class StudyTeamService {
                 await this.studyTeamRepository.getStudyTeamMembersById(
                     studyTeamId,
                 );
+            // 기존 스터디 팀 정보 조회
+            const existingStudyTeam =
+                await this.studyTeamRepository.getStudyTeamById(studyTeamId);
+            const wasRecruited = existingStudyTeam.isRecruited;
 
             const updatedMembers = [
                 ...existingMembers.filter(
@@ -326,6 +349,47 @@ export class StudyTeamService {
                 updateStudyTeamDto.resultImages,
                 updateStudyTeamDto.studyMember,
             );
+
+            // 🔹 isRecruited 값이 false → true 로 변경되었을 때 Slack 알림 전송
+            if (!wasRecruited && studyData.isRecruited) {
+                this.logger.debug(
+                    '📢 [INFO] 스터디 모집이 시작되어 Slack 알림을 전송합니다.',
+                );
+
+                // 리더 정보 가져오기
+                const leaderMembers = studyData.studyMember.filter(
+                    (member) => member.isLeader,
+                );
+
+                // 리더 이름과 이메일을 배열로 저장
+                const leaderNames = leaderMembers.length
+                    ? leaderMembers.map((leader) => leader.name) // 🔹 배열 유지
+                    : ['Unknown Leader'];
+
+                const leaderEmails = leaderMembers.length
+                    ? leaderMembers.map((leader) => leader.email) // 🔹 배열 유지
+                    : ['No Email'];
+
+                // Slack 알림 Payload 생성
+                const slackPayload: CreateStudyAlertRequest = {
+                    id: studyData.id,
+                    type: 'study', // 스터디 타입
+                    name: studyData.name,
+                    studyExplain: studyData.studyExplain,
+                    recruitNum: studyData.recruitNum,
+                    leader: leaderNames, // 모든 리더 표시
+                    email: leaderEmails, // 모든 리더 이메일 표시
+                    recruitExplain: studyData.recruitExplain,
+                    notionLink: studyData.notionLink,
+                    goal: studyData.goal,
+                    rule: studyData.rule,
+                };
+
+                this.logger.debug(JSON.stringify(slackPayload));
+
+                // Slack 알림 전송
+                await this.alertService.sendSlackAlert(slackPayload);
+            }
 
             // 인덱스 업데이트
             const indexStudy = new IndexStudyRequest(studyData);


### PR DESCRIPTION
## 작업 내용
리더가 여러명인 경우 여러명중 랜덤의 한명의 리더에게 개인 슬랙 알림이 보내지고 있었는데 이제 모든 리더에게 알림 보낼 수 있게 수정했습니다. 
<br><br>

## 참고 사항
데이터는 다음과 같습니다. 
[ FIND_MEMBER 채널 데이터 ]
 {
    "id":2,
    "type":"project",
    "name":"프로젝트 sdf이름",
    "projectExplain":"프로젝트에 대한 설명입니다.",
    "frontNum":1,
    "backNum":1,
    "dataEngNum":0,
    "devOpsNum":0,
    "fullStackNum":0,
    "leader":["테커짱","테커짱2"], // 이부분을 배열로 바꿨습니다.
    "email":["test1@example.com","test2@example.com"], // 이부분을 배열로 바꿨습니다.
    "recruitExplain":"시간 약속을 잘 지키는 사람을 원합니다.",
    "notionLink":"https://notion.so/techeerism",
    "stack":["React.js","Node.js"]
}

[ 슬랙 개인 디엠 알림 ]
[{
    "teamId":2,
    "teamName":"프로젝트 이름",
    "type":"project",
    "leaderEmail":"test1@example.com",
    "applicantEmail":"test3@example.com",
    "result":"PENDING"
}]
[{
    "teamId":2,
    "teamName":"프로젝트 이름",
    "type":"project",
    "leaderEmail":"test2@example.com",
    "applicantEmail":"Null",
    "result":"PENDING"
}]
만약 리더가 2명이면 슬랙 알림을 2번 요청 보내는데, 첫번째에만 지원자의 이메일이 포함되고 그 다음의 요청에 경우에는 포함되지 않고 NULL이 들어갑니다!
<br><br>

## 관련 이슈
BACKEND-5

<br><br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 알림 기능이 개선되어 단일 및 복수 알림 요청을 지원합니다.
	- 프로젝트와 스터디 알림에서 팀 리더 및 이메일 정보를 다중으로 입력할 수 있습니다.
	- 이미지 업로드 시 허용되는 파일 형식이 확대되어 다양한 포맷 업로드가 가능합니다.
	- 모집 상태 변경 시 전체 팀 리더에게 실시간 알림이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->